### PR TITLE
Relicense repository under the Rojo Developers

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Lucien Greathouse
+Copyright (c) 2019-2025 The Rojo Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I noticed that this repository is still licensed to be owned by Lucien. After sending him an email and getting written permission, we are relicensing it to be owned by the Rojo Developers.

I can attach the email I received if anyone wants proof, but I generally default to not attaching emails to things unless I have to.